### PR TITLE
feat: Start vite from hardhat after contracts deployed

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -1,1 +1,0 @@
-VITE_DEFAULT_RPC="http://localhost:8545"

--- a/client/package.json
+++ b/client/package.json
@@ -19,16 +19,6 @@
     "tinycolor2": "^1.4.2"
   },
   "scripts": {},
-  "browserslist": {
-    "production": [
-      "last 1 chrome version",
-      "last 1 firefox version"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version"
-    ]
-  },
   "engines": {
     "node": "^16"
   },

--- a/client/package.json
+++ b/client/package.json
@@ -33,13 +33,11 @@
     "node": "^16"
   },
   "devDependencies": {
-    "@sveltejs/vite-plugin-svelte": "^1.0.1",
     "@types/tinycolor2": "^1.4.3",
     "autoprefixer": "^10.4.7",
     "postcss": "^8.4.14",
     "svelte": "^3.49.0",
-    "svelte-preprocess": "^4.10.7",
     "tailwindcss": "^3.1.6",
-    "vite": "^3.0.5"
+    "vite": "^3.1.0"
   }
 }

--- a/client/package.json
+++ b/client/package.json
@@ -18,9 +18,7 @@
     "events": "^3.3.0",
     "tinycolor2": "^1.4.2"
   },
-  "scripts": {
-    "start": "vite"
-  },
+  "scripts": {},
   "browserslist": {
     "production": [
       "last 1 chrome version",

--- a/client/src/backend/Blockchain.ts
+++ b/client/src/backend/Blockchain.ts
@@ -16,16 +16,5 @@ export async function loadCoreContract(
 }
 
 export function getEthConnection(): ConnectionManager {
-  const isProd = import.meta.env.MODE === 'production';
-  const defaultUrl = import.meta.env.VITE_DEFAULT_RPC;
-
-  let url: string;
-
-  if (isProd) {
-    url = defaultUrl;
-  } else {
-    url = 'http://localhost:8545';
-  }
-
-  return new ConnectionManager(url);
+  return new ConnectionManager(import.meta.env.RPC_URL);
 }

--- a/client/src/vite-env.d.ts
+++ b/client/src/vite-env.d.ts
@@ -2,7 +2,7 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
-  VITE_DEFAULT_RPC: string;
+  RPC_URL: string;
 }
 
 interface Window {

--- a/client/svelte.config.js
+++ b/client/svelte.config.js
@@ -1,7 +1,0 @@
-import sveltePreprocess from 'svelte-preprocess';
-
-export default {
-  // Consult https://github.com/sveltejs/svelte-preprocess
-  // for more information about preprocessors
-  preprocess: sveltePreprocess(),
-};

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,8 +1,0 @@
-import { defineConfig } from 'vite';
-import { svelte } from '@sveltejs/vite-plugin-svelte';
-
-// https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [svelte()],
-  assetsInclude: ['**/*.zkey'],
-});

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -5,9 +5,4 @@ import { svelte } from '@sveltejs/vite-plugin-svelte';
 export default defineConfig({
   plugins: [svelte()],
   assetsInclude: ['**/*.zkey'],
-  optimizeDeps: {
-    esbuildOptions: {
-      target: 'es2020',
-    },
-  },
 });

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -10,6 +10,7 @@ import '@typechain/hardhat';
 import 'hardhat-circom';
 import 'hardhat-contract-sizer';
 import 'hardhat-settings';
+import 'hardhat-vite';
 import '@solidstate/hardhat-4byte-uploader';
 
 // Our Hardhat tasks
@@ -21,6 +22,8 @@ import 'hardhat-tasks/circom';
 import type { HardhatRuntimeEnvironment, HardhatUserConfig } from 'hardhat/types';
 import { extendEnvironment } from 'hardhat/config';
 import * as diamondUtils from 'hardhat-tasks/utils/diamond';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import sveltePreprocess from 'svelte-preprocess';
 
 //@ts-ignore because they don't provide types
 import * as mapWorkspaces from '@npmcli/map-workspaces';
@@ -207,6 +210,17 @@ const config: HardhatUserConfig = {
     zkgame: {
       lazy: false,
     },
+  },
+  vite: {
+    root: packages.get('client'),
+    envFile: false,
+    plugins: [
+      svelte({
+        // Consult https://github.com/sveltejs/svelte-preprocess for details about preprocessors
+        preprocess: sveltePreprocess(),
+      }),
+    ],
+    assetsInclude: ['**/*.zkey'],
   },
 };
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -60,7 +60,6 @@ const config: HardhatUserConfig = {
    */
   networks: {
     localhost: {
-      url: 'http://localhost:8545/',
       accounts: {
         mnemonic: 'change typical hire slam amateur loan grid fix drama electric seed label',
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@npmcli/map-workspaces": "^2.0.3",
         "@projectsophon/tsconfig": "^0.1.1",
         "@solidstate/hardhat-4byte-uploader": "^1.0.2",
+        "@sveltejs/vite-plugin-svelte": "^1.0.1",
         "@typechain/ethers-v5": "10.1.0",
         "@typechain/hardhat": "^6.1.2",
         "hardhat": "^2.10.1",
@@ -31,6 +32,8 @@
         "hardhat-contract-sizer": "^2.6.1",
         "hardhat-diamond-abi": "^3.0.1",
         "hardhat-settings": "^1.0.0",
+        "hardhat-vite": "^1.0.0",
+        "svelte-preprocess": "^4.10.7",
         "ts-node": "^10.9.1",
         "typechain": "8.1.0",
         "typescript": "4.7.x"
@@ -60,14 +63,12 @@
         "tinycolor2": "^1.4.2"
       },
       "devDependencies": {
-        "@sveltejs/vite-plugin-svelte": "^1.0.1",
         "@types/tinycolor2": "^1.4.3",
         "autoprefixer": "^10.4.7",
         "postcss": "^8.4.14",
         "svelte": "^3.49.0",
-        "svelte-preprocess": "^4.10.7",
         "tailwindcss": "^3.1.6",
-        "vite": "^3.0.5"
+        "vite": "^3.1.0"
       },
       "engines": {
         "node": "^16"
@@ -467,9 +468,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz",
-      "integrity": "sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.7.tgz",
+      "integrity": "sha512-IKznSJOsVUuyt7cDzzSZyqBEcZe+7WlBqTVXiF1OXP/4Nm387ToaXZ0fyLwI1iBlI/bzpxVq411QE2/Bt2XWWw==",
       "cpu": [
         "loong64"
       ],
@@ -4426,9 +4427,9 @@
       "dev": true
     },
     "node_modules/esbuild": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.54.tgz",
-      "integrity": "sha512-Cy9llcy8DvET5uznocPyqL3BFRrFXSVqbgpMJ9Wz8oVjZlh/zUSNbPRbov0VX7VxN2JH1Oa0uNxZ7eLRb62pJA==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.7.tgz",
+      "integrity": "sha512-7V8tzllIbAQV1M4QoE52ImKu8hT/NLGlGXkiDsbEU5PS6K8Mn09ZnYoS+dcmHxOS9CRsV4IRAMdT3I67IyUNXw==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -4438,33 +4439,33 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/linux-loong64": "0.14.54",
-        "esbuild-android-64": "0.14.54",
-        "esbuild-android-arm64": "0.14.54",
-        "esbuild-darwin-64": "0.14.54",
-        "esbuild-darwin-arm64": "0.14.54",
-        "esbuild-freebsd-64": "0.14.54",
-        "esbuild-freebsd-arm64": "0.14.54",
-        "esbuild-linux-32": "0.14.54",
-        "esbuild-linux-64": "0.14.54",
-        "esbuild-linux-arm": "0.14.54",
-        "esbuild-linux-arm64": "0.14.54",
-        "esbuild-linux-mips64le": "0.14.54",
-        "esbuild-linux-ppc64le": "0.14.54",
-        "esbuild-linux-riscv64": "0.14.54",
-        "esbuild-linux-s390x": "0.14.54",
-        "esbuild-netbsd-64": "0.14.54",
-        "esbuild-openbsd-64": "0.14.54",
-        "esbuild-sunos-64": "0.14.54",
-        "esbuild-windows-32": "0.14.54",
-        "esbuild-windows-64": "0.14.54",
-        "esbuild-windows-arm64": "0.14.54"
+        "@esbuild/linux-loong64": "0.15.7",
+        "esbuild-android-64": "0.15.7",
+        "esbuild-android-arm64": "0.15.7",
+        "esbuild-darwin-64": "0.15.7",
+        "esbuild-darwin-arm64": "0.15.7",
+        "esbuild-freebsd-64": "0.15.7",
+        "esbuild-freebsd-arm64": "0.15.7",
+        "esbuild-linux-32": "0.15.7",
+        "esbuild-linux-64": "0.15.7",
+        "esbuild-linux-arm": "0.15.7",
+        "esbuild-linux-arm64": "0.15.7",
+        "esbuild-linux-mips64le": "0.15.7",
+        "esbuild-linux-ppc64le": "0.15.7",
+        "esbuild-linux-riscv64": "0.15.7",
+        "esbuild-linux-s390x": "0.15.7",
+        "esbuild-netbsd-64": "0.15.7",
+        "esbuild-openbsd-64": "0.15.7",
+        "esbuild-sunos-64": "0.15.7",
+        "esbuild-windows-32": "0.15.7",
+        "esbuild-windows-64": "0.15.7",
+        "esbuild-windows-arm64": "0.15.7"
       }
     },
     "node_modules/esbuild-android-64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.54.tgz",
-      "integrity": "sha512-Tz2++Aqqz0rJ7kYBfz+iqyE3QMycD4vk7LBRyWaAVFgFtQ/O8EJOnVmTOiDWYZ/uYzB4kvP+bqejYdVKzE5lAQ==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.7.tgz",
+      "integrity": "sha512-p7rCvdsldhxQr3YHxptf1Jcd86dlhvc3EQmQJaZzzuAxefO9PvcI0GLOa5nCWem1AJ8iMRu9w0r5TG8pHmbi9w==",
       "cpu": [
         "x64"
       ],
@@ -4478,9 +4479,9 @@
       }
     },
     "node_modules/esbuild-android-arm64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.54.tgz",
-      "integrity": "sha512-F9E+/QDi9sSkLaClO8SOV6etqPd+5DgJje1F9lOWoNncDdOBL2YF59IhsWATSt0TLZbYCf3pNlTHvVV5VfHdvg==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.7.tgz",
+      "integrity": "sha512-L775l9ynJT7rVqRM5vo+9w5g2ysbOCfsdLV4CWanTZ1k/9Jb3IYlQ06VCI1edhcosTYJRECQFJa3eAvkx72eyQ==",
       "cpu": [
         "arm64"
       ],
@@ -4494,9 +4495,9 @@
       }
     },
     "node_modules/esbuild-darwin-64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.54.tgz",
-      "integrity": "sha512-jtdKWV3nBviOd5v4hOpkVmpxsBy90CGzebpbO9beiqUYVMBtSc0AL9zGftFuBon7PNDcdvNCEuQqw2x0wP9yug==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.7.tgz",
+      "integrity": "sha512-KGPt3r1c9ww009t2xLB6Vk0YyNOXh7hbjZ3EecHoVDxgtbUlYstMPDaReimKe6eOEfyY4hBEEeTvKwPsiH5WZg==",
       "cpu": [
         "x64"
       ],
@@ -4510,9 +4511,9 @@
       }
     },
     "node_modules/esbuild-darwin-arm64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.54.tgz",
-      "integrity": "sha512-OPafJHD2oUPyvJMrsCvDGkRrVCar5aVyHfWGQzY1dWnzErjrDuSETxwA2HSsyg2jORLY8yBfzc1MIpUkXlctmw==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.7.tgz",
+      "integrity": "sha512-kBIHvtVqbSGajN88lYMnR3aIleH3ABZLLFLxwL2stiuIGAjGlQW741NxVTpUHQXUmPzxi6POqc9npkXa8AcSZQ==",
       "cpu": [
         "arm64"
       ],
@@ -4526,9 +4527,9 @@
       }
     },
     "node_modules/esbuild-freebsd-64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.54.tgz",
-      "integrity": "sha512-OKwd4gmwHqOTp4mOGZKe/XUlbDJ4Q9TjX0hMPIDBUWWu/kwhBAudJdBoxnjNf9ocIB6GN6CPowYpR/hRCbSYAg==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.7.tgz",
+      "integrity": "sha512-hESZB91qDLV5MEwNxzMxPfbjAhOmtfsr9Wnuci7pY6TtEh4UDuevmGmkUIjX/b+e/k4tcNBMf7SRQ2mdNuK/HQ==",
       "cpu": [
         "x64"
       ],
@@ -4542,9 +4543,9 @@
       }
     },
     "node_modules/esbuild-freebsd-arm64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.54.tgz",
-      "integrity": "sha512-sFwueGr7OvIFiQT6WeG0jRLjkjdqWWSrfbVwZp8iMP+8UHEHRBvlaxL6IuKNDwAozNUmbb8nIMXa7oAOARGs1Q==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.7.tgz",
+      "integrity": "sha512-dLFR0ChH5t+b3J8w0fVKGvtwSLWCv7GYT2Y2jFGulF1L5HftQLzVGN+6pi1SivuiVSmTh28FwUhi9PwQicXI6Q==",
       "cpu": [
         "arm64"
       ],
@@ -4558,9 +4559,9 @@
       }
     },
     "node_modules/esbuild-linux-32": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.54.tgz",
-      "integrity": "sha512-1ZuY+JDI//WmklKlBgJnglpUL1owm2OX+8E1syCD6UAxcMM/XoWd76OHSjl/0MR0LisSAXDqgjT3uJqT67O3qw==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.7.tgz",
+      "integrity": "sha512-v3gT/LsONGUZcjbt2swrMjwxo32NJzk+7sAgtxhGx1+ZmOFaTRXBAi1PPfgpeo/J//Un2jIKm/I+qqeo4caJvg==",
       "cpu": [
         "ia32"
       ],
@@ -4574,9 +4575,9 @@
       }
     },
     "node_modules/esbuild-linux-64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.54.tgz",
-      "integrity": "sha512-EgjAgH5HwTbtNsTqQOXWApBaPVdDn7XcK+/PtJwZLT1UmpLoznPd8c5CxqsH2dQK3j05YsB3L17T8vE7cp4cCg==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.7.tgz",
+      "integrity": "sha512-LxXEfLAKwOVmm1yecpMmWERBshl+Kv5YJ/1KnyAr6HRHFW8cxOEsEfisD3sVl/RvHyW//lhYUVSuy9jGEfIRAQ==",
       "cpu": [
         "x64"
       ],
@@ -4590,9 +4591,9 @@
       }
     },
     "node_modules/esbuild-linux-arm": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.54.tgz",
-      "integrity": "sha512-qqz/SjemQhVMTnvcLGoLOdFpCYbz4v4fUo+TfsWG+1aOu70/80RV6bgNpR2JCrppV2moUQkww+6bWxXRL9YMGw==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.7.tgz",
+      "integrity": "sha512-JKgAHtMR5f75wJTeuNQbyznZZa+pjiUHV7sRZp42UNdyXC6TiUYMW/8z8yIBAr2Fpad8hM1royZKQisqPABPvQ==",
       "cpu": [
         "arm"
       ],
@@ -4606,9 +4607,9 @@
       }
     },
     "node_modules/esbuild-linux-arm64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.54.tgz",
-      "integrity": "sha512-WL71L+0Rwv+Gv/HTmxTEmpv0UgmxYa5ftZILVi2QmZBgX3q7+tDeOQNqGtdXSdsL8TQi1vIaVFHUPDe0O0kdig==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.7.tgz",
+      "integrity": "sha512-P3cfhudpzWDkglutWgXcT2S7Ft7o2e3YDMrP1n0z2dlbUZghUkKCyaWw0zhp4KxEEzt/E7lmrtRu/pGWnwb9vw==",
       "cpu": [
         "arm64"
       ],
@@ -4622,9 +4623,9 @@
       }
     },
     "node_modules/esbuild-linux-mips64le": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.54.tgz",
-      "integrity": "sha512-qTHGQB8D1etd0u1+sB6p0ikLKRVuCWhYQhAHRPkO+OF3I/iSlTKNNS0Lh2Oc0g0UFGguaFZZiPJdJey3AGpAlw==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.7.tgz",
+      "integrity": "sha512-T7XKuxl0VpeFLCJXub6U+iybiqh0kM/bWOTb4qcPyDDwNVhLUiPcGdG2/0S7F93czUZOKP57YiLV8YQewgLHKw==",
       "cpu": [
         "mips64el"
       ],
@@ -4638,9 +4639,9 @@
       }
     },
     "node_modules/esbuild-linux-ppc64le": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.54.tgz",
-      "integrity": "sha512-j3OMlzHiqwZBDPRCDFKcx595XVfOfOnv68Ax3U4UKZ3MTYQB5Yz3X1mn5GnodEVYzhtZgxEBidLWeIs8FDSfrQ==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.7.tgz",
+      "integrity": "sha512-6mGuC19WpFN7NYbecMIJjeQgvDb5aMuvyk0PDYBJrqAEMkTwg3Z98kEKuCm6THHRnrgsdr7bp4SruSAxEM4eJw==",
       "cpu": [
         "ppc64"
       ],
@@ -4654,9 +4655,9 @@
       }
     },
     "node_modules/esbuild-linux-riscv64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.54.tgz",
-      "integrity": "sha512-y7Vt7Wl9dkOGZjxQZnDAqqn+XOqFD7IMWiewY5SPlNlzMX39ocPQlOaoxvT4FllA5viyV26/QzHtvTjVNOxHZg==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.7.tgz",
+      "integrity": "sha512-uUJsezbswAYo/X7OU/P+PuL/EI9WzxsEQXDekfwpQ23uGiooxqoLFAPmXPcRAt941vjlY9jtITEEikWMBr+F/g==",
       "cpu": [
         "riscv64"
       ],
@@ -4670,9 +4671,9 @@
       }
     },
     "node_modules/esbuild-linux-s390x": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.54.tgz",
-      "integrity": "sha512-zaHpW9dziAsi7lRcyV4r8dhfG1qBidQWUXweUjnw+lliChJqQr+6XD71K41oEIC3Mx1KStovEmlzm+MkGZHnHA==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.7.tgz",
+      "integrity": "sha512-+tO+xOyTNMc34rXlSxK7aCwJgvQyffqEM5MMdNDEeMU3ss0S6wKvbBOQfgd5jRPblfwJ6b+bKiz0g5nABpY0QQ==",
       "cpu": [
         "s390x"
       ],
@@ -4686,9 +4687,9 @@
       }
     },
     "node_modules/esbuild-netbsd-64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.54.tgz",
-      "integrity": "sha512-PR01lmIMnfJTgeU9VJTDY9ZerDWVFIUzAtJuDHwwceppW7cQWjBBqP48NdeRtoP04/AtO9a7w3viI+PIDr6d+w==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.7.tgz",
+      "integrity": "sha512-yVc4Wz+Pu3cP5hzm5kIygNPrjar/v5WCSoRmIjCPWfBVJkZNb5brEGKUlf+0Y759D48BCWa0WHrWXaNy0DULTQ==",
       "cpu": [
         "x64"
       ],
@@ -4702,9 +4703,9 @@
       }
     },
     "node_modules/esbuild-openbsd-64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.54.tgz",
-      "integrity": "sha512-Qyk7ikT2o7Wu76UsvvDS5q0amJvmRzDyVlL0qf5VLsLchjCa1+IAvd8kTBgUxD7VBUUVgItLkk609ZHUc1oCaw==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.7.tgz",
+      "integrity": "sha512-GsimbwC4FSR4lN3wf8XmTQ+r8/0YSQo21rWDL0XFFhLHKlzEA4SsT1Tl8bPYu00IU6UWSJ+b3fG/8SB69rcuEQ==",
       "cpu": [
         "x64"
       ],
@@ -4718,9 +4719,9 @@
       }
     },
     "node_modules/esbuild-sunos-64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.54.tgz",
-      "integrity": "sha512-28GZ24KmMSeKi5ueWzMcco6EBHStL3B6ubM7M51RmPwXQGLe0teBGJocmWhgwccA1GeFXqxzILIxXpHbl9Q/Kw==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.7.tgz",
+      "integrity": "sha512-8CDI1aL/ts0mDGbWzjEOGKXnU7p3rDzggHSBtVryQzkSOsjCHRVe0iFYUuhczlxU1R3LN/E7HgUO4NXzGGP/Ag==",
       "cpu": [
         "x64"
       ],
@@ -4734,9 +4735,9 @@
       }
     },
     "node_modules/esbuild-windows-32": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.54.tgz",
-      "integrity": "sha512-T+rdZW19ql9MjS7pixmZYVObd9G7kcaZo+sETqNH4RCkuuYSuv9AGHUVnPoP9hhuE1WM1ZimHz1CIBHBboLU7w==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.7.tgz",
+      "integrity": "sha512-cOnKXUEPS8EGCzRSFa1x6NQjGhGsFlVgjhqGEbLTPsA7x4RRYiy2RKoArNUU4iR2vHmzqS5Gr84MEumO/wxYKA==",
       "cpu": [
         "ia32"
       ],
@@ -4750,9 +4751,9 @@
       }
     },
     "node_modules/esbuild-windows-64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.54.tgz",
-      "integrity": "sha512-AoHTRBUuYwXtZhjXZbA1pGfTo8cJo3vZIcWGLiUcTNgHpJJMC1rVA44ZereBHMJtotyN71S8Qw0npiCIkW96cQ==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.7.tgz",
+      "integrity": "sha512-7MI08Ec2sTIDv+zH6StNBKO+2hGUYIT42GmFyW6MBBWWtJhTcQLinKS6ldIN1d52MXIbiJ6nXyCJ+LpL4jBm3Q==",
       "cpu": [
         "x64"
       ],
@@ -4766,9 +4767,9 @@
       }
     },
     "node_modules/esbuild-windows-arm64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.54.tgz",
-      "integrity": "sha512-M0kuUvXhot1zOISQGXwWn6YtS+Y/1RT9WrVIOywZnJHo3jCDyewAc79aKNQWFCQm+xNHVTq9h8dZKvygoXQQRg==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.7.tgz",
+      "integrity": "sha512-R06nmqBlWjKHddhRJYlqDd3Fabx9LFdKcjoOy08YLimwmsswlFBJV4rXzZCxz/b7ZJXvrZgj8DDv1ewE9+StMw==",
       "cpu": [
         "arm64"
       ],
@@ -5683,6 +5684,21 @@
     "node_modules/hardhat-tasks": {
       "resolved": "tasks",
       "link": true
+    },
+    "node_modules/hardhat-vite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hardhat-vite/-/hardhat-vite-1.0.0.tgz",
+      "integrity": "sha512-RqCWAsVQpD1MwPke1g23ngbxOk1EN4gDQCE4lRWae475AcSd8745EloKldgp0LTnil6QgK11hYrlKpmlSzER4g==",
+      "dev": true,
+      "dependencies": {
+        "vite": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "hardhat": "^2.0.0"
+      }
     },
     "node_modules/hardhat/node_modules/ethereum-cryptography": {
       "version": "1.1.2",
@@ -8104,9 +8120,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.77.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.2.tgz",
-      "integrity": "sha512-m/4YzYgLcpMQbxX3NmAqDvwLATZzxt8bIegO78FZLl+lAgKJBd1DRAOeEiZcKOIOPjxE6ewHWHNgGEalFXuz1g==",
+      "version": "2.78.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.1.tgz",
+      "integrity": "sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -9456,15 +9472,15 @@
       }
     },
     "node_modules/vite": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-3.0.5.tgz",
-      "integrity": "sha512-bRvrt9Tw8EGW4jj64aYFTnVg134E8hgDxyl/eEHnxiGqYk7/pTPss6CWlurqPOUzqvEoZkZ58Ws+Iu8MB87iMA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-3.1.0.tgz",
+      "integrity": "sha512-YBg3dUicDpDWFCGttmvMbVyS9ydjntwEjwXRj2KBFwSB8SxmGcudo1yb8FW5+M/G86aS8x828ujnzUVdsLjs9g==",
       "dev": true,
       "dependencies": {
-        "esbuild": "^0.14.47",
+        "esbuild": "^0.15.6",
         "postcss": "^8.4.16",
         "resolve": "^1.22.1",
-        "rollup": "^2.75.6"
+        "rollup": "~2.78.0"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -9975,8 +9991,7 @@
         "ethers": "^5.6.9",
         "node-fetch": "^2.6.0",
         "ts-dedent": "^2.2.0",
-        "typescript": "4.7.x",
-        "vite": "^3.0.5"
+        "typescript": "4.7.x"
       }
     },
     "tasks/node_modules/ansi-styles": {
@@ -10358,9 +10373,9 @@
       }
     },
     "@esbuild/linux-loong64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz",
-      "integrity": "sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.7.tgz",
+      "integrity": "sha512-IKznSJOsVUuyt7cDzzSZyqBEcZe+7WlBqTVXiF1OXP/4Nm387ToaXZ0fyLwI1iBlI/bzpxVq411QE2/Bt2XWWw==",
       "dev": true,
       "optional": true
     },
@@ -12775,7 +12790,6 @@
         "@projectsophon/serde": "^0.1.3",
         "@projectsophon/snarkjs-helpers": "^0.1.3",
         "@projectsophon/types": "^0.1.3",
-        "@sveltejs/vite-plugin-svelte": "^1.0.1",
         "@types/tinycolor2": "^1.4.3",
         "@zkgame/contracts": "0.0.0",
         "@zkgame/snarks": "0.0.0",
@@ -12786,10 +12800,9 @@
         "events": "^3.3.0",
         "postcss": "^8.4.14",
         "svelte": "^3.49.0",
-        "svelte-preprocess": "^4.10.7",
         "tailwindcss": "^3.1.6",
         "tinycolor2": "^1.4.2",
-        "vite": "^3.0.5"
+        "vite": "^3.1.0"
       }
     },
     "cliui": {
@@ -13310,171 +13323,171 @@
       "dev": true
     },
     "esbuild": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.54.tgz",
-      "integrity": "sha512-Cy9llcy8DvET5uznocPyqL3BFRrFXSVqbgpMJ9Wz8oVjZlh/zUSNbPRbov0VX7VxN2JH1Oa0uNxZ7eLRb62pJA==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.7.tgz",
+      "integrity": "sha512-7V8tzllIbAQV1M4QoE52ImKu8hT/NLGlGXkiDsbEU5PS6K8Mn09ZnYoS+dcmHxOS9CRsV4IRAMdT3I67IyUNXw==",
       "dev": true,
       "requires": {
-        "@esbuild/linux-loong64": "0.14.54",
-        "esbuild-android-64": "0.14.54",
-        "esbuild-android-arm64": "0.14.54",
-        "esbuild-darwin-64": "0.14.54",
-        "esbuild-darwin-arm64": "0.14.54",
-        "esbuild-freebsd-64": "0.14.54",
-        "esbuild-freebsd-arm64": "0.14.54",
-        "esbuild-linux-32": "0.14.54",
-        "esbuild-linux-64": "0.14.54",
-        "esbuild-linux-arm": "0.14.54",
-        "esbuild-linux-arm64": "0.14.54",
-        "esbuild-linux-mips64le": "0.14.54",
-        "esbuild-linux-ppc64le": "0.14.54",
-        "esbuild-linux-riscv64": "0.14.54",
-        "esbuild-linux-s390x": "0.14.54",
-        "esbuild-netbsd-64": "0.14.54",
-        "esbuild-openbsd-64": "0.14.54",
-        "esbuild-sunos-64": "0.14.54",
-        "esbuild-windows-32": "0.14.54",
-        "esbuild-windows-64": "0.14.54",
-        "esbuild-windows-arm64": "0.14.54"
+        "@esbuild/linux-loong64": "0.15.7",
+        "esbuild-android-64": "0.15.7",
+        "esbuild-android-arm64": "0.15.7",
+        "esbuild-darwin-64": "0.15.7",
+        "esbuild-darwin-arm64": "0.15.7",
+        "esbuild-freebsd-64": "0.15.7",
+        "esbuild-freebsd-arm64": "0.15.7",
+        "esbuild-linux-32": "0.15.7",
+        "esbuild-linux-64": "0.15.7",
+        "esbuild-linux-arm": "0.15.7",
+        "esbuild-linux-arm64": "0.15.7",
+        "esbuild-linux-mips64le": "0.15.7",
+        "esbuild-linux-ppc64le": "0.15.7",
+        "esbuild-linux-riscv64": "0.15.7",
+        "esbuild-linux-s390x": "0.15.7",
+        "esbuild-netbsd-64": "0.15.7",
+        "esbuild-openbsd-64": "0.15.7",
+        "esbuild-sunos-64": "0.15.7",
+        "esbuild-windows-32": "0.15.7",
+        "esbuild-windows-64": "0.15.7",
+        "esbuild-windows-arm64": "0.15.7"
       }
     },
     "esbuild-android-64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.54.tgz",
-      "integrity": "sha512-Tz2++Aqqz0rJ7kYBfz+iqyE3QMycD4vk7LBRyWaAVFgFtQ/O8EJOnVmTOiDWYZ/uYzB4kvP+bqejYdVKzE5lAQ==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.7.tgz",
+      "integrity": "sha512-p7rCvdsldhxQr3YHxptf1Jcd86dlhvc3EQmQJaZzzuAxefO9PvcI0GLOa5nCWem1AJ8iMRu9w0r5TG8pHmbi9w==",
       "dev": true,
       "optional": true
     },
     "esbuild-android-arm64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.54.tgz",
-      "integrity": "sha512-F9E+/QDi9sSkLaClO8SOV6etqPd+5DgJje1F9lOWoNncDdOBL2YF59IhsWATSt0TLZbYCf3pNlTHvVV5VfHdvg==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.7.tgz",
+      "integrity": "sha512-L775l9ynJT7rVqRM5vo+9w5g2ysbOCfsdLV4CWanTZ1k/9Jb3IYlQ06VCI1edhcosTYJRECQFJa3eAvkx72eyQ==",
       "dev": true,
       "optional": true
     },
     "esbuild-darwin-64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.54.tgz",
-      "integrity": "sha512-jtdKWV3nBviOd5v4hOpkVmpxsBy90CGzebpbO9beiqUYVMBtSc0AL9zGftFuBon7PNDcdvNCEuQqw2x0wP9yug==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.7.tgz",
+      "integrity": "sha512-KGPt3r1c9ww009t2xLB6Vk0YyNOXh7hbjZ3EecHoVDxgtbUlYstMPDaReimKe6eOEfyY4hBEEeTvKwPsiH5WZg==",
       "dev": true,
       "optional": true
     },
     "esbuild-darwin-arm64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.54.tgz",
-      "integrity": "sha512-OPafJHD2oUPyvJMrsCvDGkRrVCar5aVyHfWGQzY1dWnzErjrDuSETxwA2HSsyg2jORLY8yBfzc1MIpUkXlctmw==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.7.tgz",
+      "integrity": "sha512-kBIHvtVqbSGajN88lYMnR3aIleH3ABZLLFLxwL2stiuIGAjGlQW741NxVTpUHQXUmPzxi6POqc9npkXa8AcSZQ==",
       "dev": true,
       "optional": true
     },
     "esbuild-freebsd-64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.54.tgz",
-      "integrity": "sha512-OKwd4gmwHqOTp4mOGZKe/XUlbDJ4Q9TjX0hMPIDBUWWu/kwhBAudJdBoxnjNf9ocIB6GN6CPowYpR/hRCbSYAg==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.7.tgz",
+      "integrity": "sha512-hESZB91qDLV5MEwNxzMxPfbjAhOmtfsr9Wnuci7pY6TtEh4UDuevmGmkUIjX/b+e/k4tcNBMf7SRQ2mdNuK/HQ==",
       "dev": true,
       "optional": true
     },
     "esbuild-freebsd-arm64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.54.tgz",
-      "integrity": "sha512-sFwueGr7OvIFiQT6WeG0jRLjkjdqWWSrfbVwZp8iMP+8UHEHRBvlaxL6IuKNDwAozNUmbb8nIMXa7oAOARGs1Q==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.7.tgz",
+      "integrity": "sha512-dLFR0ChH5t+b3J8w0fVKGvtwSLWCv7GYT2Y2jFGulF1L5HftQLzVGN+6pi1SivuiVSmTh28FwUhi9PwQicXI6Q==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-32": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.54.tgz",
-      "integrity": "sha512-1ZuY+JDI//WmklKlBgJnglpUL1owm2OX+8E1syCD6UAxcMM/XoWd76OHSjl/0MR0LisSAXDqgjT3uJqT67O3qw==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.7.tgz",
+      "integrity": "sha512-v3gT/LsONGUZcjbt2swrMjwxo32NJzk+7sAgtxhGx1+ZmOFaTRXBAi1PPfgpeo/J//Un2jIKm/I+qqeo4caJvg==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.54.tgz",
-      "integrity": "sha512-EgjAgH5HwTbtNsTqQOXWApBaPVdDn7XcK+/PtJwZLT1UmpLoznPd8c5CxqsH2dQK3j05YsB3L17T8vE7cp4cCg==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.7.tgz",
+      "integrity": "sha512-LxXEfLAKwOVmm1yecpMmWERBshl+Kv5YJ/1KnyAr6HRHFW8cxOEsEfisD3sVl/RvHyW//lhYUVSuy9jGEfIRAQ==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-arm": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.54.tgz",
-      "integrity": "sha512-qqz/SjemQhVMTnvcLGoLOdFpCYbz4v4fUo+TfsWG+1aOu70/80RV6bgNpR2JCrppV2moUQkww+6bWxXRL9YMGw==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.7.tgz",
+      "integrity": "sha512-JKgAHtMR5f75wJTeuNQbyznZZa+pjiUHV7sRZp42UNdyXC6TiUYMW/8z8yIBAr2Fpad8hM1royZKQisqPABPvQ==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-arm64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.54.tgz",
-      "integrity": "sha512-WL71L+0Rwv+Gv/HTmxTEmpv0UgmxYa5ftZILVi2QmZBgX3q7+tDeOQNqGtdXSdsL8TQi1vIaVFHUPDe0O0kdig==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.7.tgz",
+      "integrity": "sha512-P3cfhudpzWDkglutWgXcT2S7Ft7o2e3YDMrP1n0z2dlbUZghUkKCyaWw0zhp4KxEEzt/E7lmrtRu/pGWnwb9vw==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-mips64le": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.54.tgz",
-      "integrity": "sha512-qTHGQB8D1etd0u1+sB6p0ikLKRVuCWhYQhAHRPkO+OF3I/iSlTKNNS0Lh2Oc0g0UFGguaFZZiPJdJey3AGpAlw==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.7.tgz",
+      "integrity": "sha512-T7XKuxl0VpeFLCJXub6U+iybiqh0kM/bWOTb4qcPyDDwNVhLUiPcGdG2/0S7F93czUZOKP57YiLV8YQewgLHKw==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-ppc64le": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.54.tgz",
-      "integrity": "sha512-j3OMlzHiqwZBDPRCDFKcx595XVfOfOnv68Ax3U4UKZ3MTYQB5Yz3X1mn5GnodEVYzhtZgxEBidLWeIs8FDSfrQ==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.7.tgz",
+      "integrity": "sha512-6mGuC19WpFN7NYbecMIJjeQgvDb5aMuvyk0PDYBJrqAEMkTwg3Z98kEKuCm6THHRnrgsdr7bp4SruSAxEM4eJw==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-riscv64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.54.tgz",
-      "integrity": "sha512-y7Vt7Wl9dkOGZjxQZnDAqqn+XOqFD7IMWiewY5SPlNlzMX39ocPQlOaoxvT4FllA5viyV26/QzHtvTjVNOxHZg==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.7.tgz",
+      "integrity": "sha512-uUJsezbswAYo/X7OU/P+PuL/EI9WzxsEQXDekfwpQ23uGiooxqoLFAPmXPcRAt941vjlY9jtITEEikWMBr+F/g==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-s390x": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.54.tgz",
-      "integrity": "sha512-zaHpW9dziAsi7lRcyV4r8dhfG1qBidQWUXweUjnw+lliChJqQr+6XD71K41oEIC3Mx1KStovEmlzm+MkGZHnHA==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.7.tgz",
+      "integrity": "sha512-+tO+xOyTNMc34rXlSxK7aCwJgvQyffqEM5MMdNDEeMU3ss0S6wKvbBOQfgd5jRPblfwJ6b+bKiz0g5nABpY0QQ==",
       "dev": true,
       "optional": true
     },
     "esbuild-netbsd-64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.54.tgz",
-      "integrity": "sha512-PR01lmIMnfJTgeU9VJTDY9ZerDWVFIUzAtJuDHwwceppW7cQWjBBqP48NdeRtoP04/AtO9a7w3viI+PIDr6d+w==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.7.tgz",
+      "integrity": "sha512-yVc4Wz+Pu3cP5hzm5kIygNPrjar/v5WCSoRmIjCPWfBVJkZNb5brEGKUlf+0Y759D48BCWa0WHrWXaNy0DULTQ==",
       "dev": true,
       "optional": true
     },
     "esbuild-openbsd-64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.54.tgz",
-      "integrity": "sha512-Qyk7ikT2o7Wu76UsvvDS5q0amJvmRzDyVlL0qf5VLsLchjCa1+IAvd8kTBgUxD7VBUUVgItLkk609ZHUc1oCaw==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.7.tgz",
+      "integrity": "sha512-GsimbwC4FSR4lN3wf8XmTQ+r8/0YSQo21rWDL0XFFhLHKlzEA4SsT1Tl8bPYu00IU6UWSJ+b3fG/8SB69rcuEQ==",
       "dev": true,
       "optional": true
     },
     "esbuild-sunos-64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.54.tgz",
-      "integrity": "sha512-28GZ24KmMSeKi5ueWzMcco6EBHStL3B6ubM7M51RmPwXQGLe0teBGJocmWhgwccA1GeFXqxzILIxXpHbl9Q/Kw==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.7.tgz",
+      "integrity": "sha512-8CDI1aL/ts0mDGbWzjEOGKXnU7p3rDzggHSBtVryQzkSOsjCHRVe0iFYUuhczlxU1R3LN/E7HgUO4NXzGGP/Ag==",
       "dev": true,
       "optional": true
     },
     "esbuild-windows-32": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.54.tgz",
-      "integrity": "sha512-T+rdZW19ql9MjS7pixmZYVObd9G7kcaZo+sETqNH4RCkuuYSuv9AGHUVnPoP9hhuE1WM1ZimHz1CIBHBboLU7w==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.7.tgz",
+      "integrity": "sha512-cOnKXUEPS8EGCzRSFa1x6NQjGhGsFlVgjhqGEbLTPsA7x4RRYiy2RKoArNUU4iR2vHmzqS5Gr84MEumO/wxYKA==",
       "dev": true,
       "optional": true
     },
     "esbuild-windows-64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.54.tgz",
-      "integrity": "sha512-AoHTRBUuYwXtZhjXZbA1pGfTo8cJo3vZIcWGLiUcTNgHpJJMC1rVA44ZereBHMJtotyN71S8Qw0npiCIkW96cQ==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.7.tgz",
+      "integrity": "sha512-7MI08Ec2sTIDv+zH6StNBKO+2hGUYIT42GmFyW6MBBWWtJhTcQLinKS6ldIN1d52MXIbiJ6nXyCJ+LpL4jBm3Q==",
       "dev": true,
       "optional": true
     },
     "esbuild-windows-arm64": {
-      "version": "0.14.54",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.54.tgz",
-      "integrity": "sha512-M0kuUvXhot1zOISQGXwWn6YtS+Y/1RT9WrVIOywZnJHo3jCDyewAc79aKNQWFCQm+xNHVTq9h8dZKvygoXQQRg==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.7.tgz",
+      "integrity": "sha512-R06nmqBlWjKHddhRJYlqDd3Fabx9LFdKcjoOy08YLimwmsswlFBJV4rXzZCxz/b7ZJXvrZgj8DDv1ewE9+StMw==",
       "dev": true,
       "optional": true
     },
@@ -14225,8 +14238,7 @@
         "ethers": "^5.6.9",
         "node-fetch": "^2.6.0",
         "ts-dedent": "^2.2.0",
-        "typescript": "4.7.x",
-        "vite": "^3.0.5"
+        "typescript": "4.7.x"
       },
       "dependencies": {
         "ansi-styles": {
@@ -14278,6 +14290,15 @@
             "has-flag": "^4.0.0"
           }
         }
+      }
+    },
+    "hardhat-vite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hardhat-vite/-/hardhat-vite-1.0.0.tgz",
+      "integrity": "sha512-RqCWAsVQpD1MwPke1g23ngbxOk1EN4gDQCE4lRWae475AcSd8745EloKldgp0LTnil6QgK11hYrlKpmlSzER4g==",
+      "dev": true,
+      "requires": {
+        "vite": "^3.1.0"
       }
     },
     "has": {
@@ -16002,9 +16023,9 @@
       }
     },
     "rollup": {
-      "version": "2.77.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.2.tgz",
-      "integrity": "sha512-m/4YzYgLcpMQbxX3NmAqDvwLATZzxt8bIegO78FZLl+lAgKJBd1DRAOeEiZcKOIOPjxE6ewHWHNgGEalFXuz1g==",
+      "version": "2.78.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.1.tgz",
+      "integrity": "sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
@@ -16982,16 +17003,16 @@
       }
     },
     "vite": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-3.0.5.tgz",
-      "integrity": "sha512-bRvrt9Tw8EGW4jj64aYFTnVg134E8hgDxyl/eEHnxiGqYk7/pTPss6CWlurqPOUzqvEoZkZ58Ws+Iu8MB87iMA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-3.1.0.tgz",
+      "integrity": "sha512-YBg3dUicDpDWFCGttmvMbVyS9ydjntwEjwXRj2KBFwSB8SxmGcudo1yb8FW5+M/G86aS8x828ujnzUVdsLjs9g==",
       "dev": true,
       "requires": {
-        "esbuild": "^0.14.47",
+        "esbuild": "^0.15.6",
         "fsevents": "~2.3.2",
         "postcss": "^8.4.16",
         "resolve": "^1.22.1",
-        "rollup": "^2.75.6"
+        "rollup": "~2.78.0"
       },
       "dependencies": {
         "resolve": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9975,7 +9975,8 @@
         "ethers": "^5.6.9",
         "node-fetch": "^2.6.0",
         "ts-dedent": "^2.2.0",
-        "typescript": "4.7.x"
+        "typescript": "4.7.x",
+        "vite": "^3.0.5"
       }
     },
     "tasks/node_modules/ansi-styles": {
@@ -14224,7 +14225,8 @@
         "ethers": "^5.6.9",
         "node-fetch": "^2.6.0",
         "ts-dedent": "^2.2.0",
-        "typescript": "4.7.x"
+        "typescript": "4.7.x",
+        "vite": "^3.0.5"
       },
       "dependencies": {
         "ansi-styles": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@npmcli/map-workspaces": "^2.0.3",
     "@projectsophon/tsconfig": "^0.1.1",
     "@solidstate/hardhat-4byte-uploader": "^1.0.2",
+    "@sveltejs/vite-plugin-svelte": "^1.0.1",
     "@typechain/ethers-v5": "10.1.0",
     "@typechain/hardhat": "^6.1.2",
     "hardhat": "^2.10.1",
@@ -38,6 +39,8 @@
     "hardhat-contract-sizer": "^2.6.1",
     "hardhat-diamond-abi": "^3.0.1",
     "hardhat-settings": "^1.0.0",
+    "hardhat-vite": "^1.0.0",
+    "svelte-preprocess": "^4.10.7",
     "ts-node": "^10.9.1",
     "typechain": "8.1.0",
     "typescript": "4.7.x"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "scripts": {
     "prepare": "workspaces-to-typescript-project-references --tsconfigPath tsconfig.ref.json",
-    "start": "hardhat node --hostname 0.0.0.0",
+    "start": "hardhat node",
     "compile": "hardhat compile",
     "circom:dev": "hardhat circom --debug --verbose",
     "circom:prod": "hardhat circom --verbose",

--- a/tasks/node.ts
+++ b/tasks/node.ts
@@ -1,7 +1,7 @@
 import type { HardhatRuntimeEnvironment, RunSuperFunction } from 'hardhat/types';
 import { subtask } from 'hardhat/config';
 import { TASK_NODE_SERVER_READY } from 'hardhat/builtin-tasks/task-names';
-import * as vite from 'vite';
+import { TASK_VITE } from 'hardhat-vite';
 
 subtask(TASK_NODE_SERVER_READY, nodeReady);
 
@@ -14,21 +14,11 @@ async function nodeReady(
 
   await hre.run('deploy');
 
-  const server = await vite.createServer({
-    root: hre.packages.get('client'),
-    envFile: false,
-    optimizeDeps: {
-      // This is needed to support BigInt out-of-the-box
-      esbuildOptions: {
-        target: 'es2020',
-      },
+  await hre.run(TASK_VITE, {
+    command: 'serve',
+    // Adding things here will be available in `import.meta.env`
+    env: {
+      RPC_URL: `http://${args.address}:${args.port}`,
     },
   });
-
-  // Adding things here will be available in `import.meta.env`
-  server.config.env.RPC_URL = `http://${args.address}:${args.port}`;
-
-  await server.listen();
-
-  server.printUrls();
 }

--- a/tasks/node.ts
+++ b/tasks/node.ts
@@ -1,15 +1,34 @@
 import type { HardhatRuntimeEnvironment, RunSuperFunction } from 'hardhat/types';
 import { subtask } from 'hardhat/config';
 import { TASK_NODE_SERVER_READY } from 'hardhat/builtin-tasks/task-names';
+import * as vite from 'vite';
 
 subtask(TASK_NODE_SERVER_READY, nodeReady);
 
 async function nodeReady(
-  args: unknown,
+  args: { address: string; port: number },
   hre: HardhatRuntimeEnvironment,
-  runSuper: RunSuperFunction<unknown>
+  runSuper: RunSuperFunction<{ address: string; port: number }>
 ) {
   await runSuper(args);
 
   await hre.run('deploy');
+
+  const server = await vite.createServer({
+    root: hre.packages.get('client'),
+    envFile: false,
+    optimizeDeps: {
+      // This is needed to support BigInt out-of-the-box
+      esbuildOptions: {
+        target: 'es2020',
+      },
+    },
+  });
+
+  // Adding things here will be available in `import.meta.env`
+  server.config.env.RPC_URL = `http://${args.address}:${args.port}`;
+
+  await server.listen();
+
+  server.printUrls();
 }

--- a/tasks/package.json
+++ b/tasks/package.json
@@ -13,7 +13,6 @@
     "ethers": "^5.6.9",
     "node-fetch": "^2.6.0",
     "ts-dedent": "^2.2.0",
-    "typescript": "4.7.x",
-    "vite": "^3.0.5"
+    "typescript": "4.7.x"
   }
 }

--- a/tasks/package.json
+++ b/tasks/package.json
@@ -13,6 +13,7 @@
     "ethers": "^5.6.9",
     "node-fetch": "^2.6.0",
     "ts-dedent": "^2.2.0",
-    "typescript": "4.7.x"
+    "typescript": "4.7.x",
+    "vite": "^3.0.5"
   }
 }


### PR DESCRIPTION
This moves the `vite` start command into the hardhat task that runs after the node is started. It waits until the contracts are deployed before it starts the server and even injects the RPC_URL based on the node. This allows `.env.example` to be dropped completely (a future improvement can be to feed the `import.meta.env` from the `hardhat-settings` files).

I plan to turn this code into a hardhat plugin but wanted to see it in action first.